### PR TITLE
Fix not saved data when pasted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,11 @@ class Paragraph {
      * @param api
      * @param readOnly
      */
-    constructor({data, config, api, readOnly}) {
+    constructor({data, config, api, readOnly, block}) {
         this.api = api;
         this.config = config;
         this.readOnly = readOnly;
+        this.block = block;
         this._CSS = {
             block: this.api.styles.block,
             wrapper: 'ce-paragraph',
@@ -218,6 +219,7 @@ class Paragraph {
         };
 
         this.data = data;
+        this.api.blocks.update(this.block.id, this.data);
     }
 
     /**


### PR DESCRIPTION
Hi @kaaaaaaaaaaai, I fixed a bug related with onPaste.

> Note:
> - It is not reproduced if to make paragraphs manually
> - It is not reproduced if to copy paste text without paragraphs
> 
> Preconditions:
> - Text with 2 paragraphs is ready to be copy pasted
> 
> Steps:
> - Copy 2 paragraphs and paste to ditor
> 
> Result:
> - Pasted text is not saved
> 
> Expected Result:
> - Pasted text should be saved correctly
> 
> 
> 